### PR TITLE
Added canonical to head.html

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -16,7 +16,12 @@
     {{ end -}}
   </title>
   <meta name="description" content="{{ partial "utils/page-description.html" . }}" />
-  <link rel="canonical" href="{{ .Permalink }}">
+  
+  {{ with .Params.canonical }}
+    <link rel="canonical" href="{{ . }}" itemprop="url" />
+  {{ else }}
+    <link rel="canonical" href="{{ .Permalink }}" itemprop="url" />
+  {{ end }}
 
   {{ partial "opengraph.html" . }}
   {{ template "_internal/schema.html" . -}}


### PR DESCRIPTION
By adding `canonical` parameter to the front matter and specifying the URL, the canonical URL is added.  If no canonical URL is needed to be specified, the layout will use the current page address for canonical tag. 

Example: 

```
---
title: "Page Title"
description: "Page description"
canonical: "https://canonicalurl.com"
---